### PR TITLE
Ability to get multiple pooled monobehaviours

### DIFF
--- a/Runtime/ObjectPoolManager.cs
+++ b/Runtime/ObjectPoolManager.cs
@@ -1,14 +1,16 @@
 using System.Collections.Generic;
 using UnityEngine;
+// ReSharper disable InconsistentNaming
 
 namespace Yonii8.Unity.ObjectPooling
 {
     public class ObjectPoolManager : MonoBehaviour
     {
-        public static ObjectPoolManager Instance;
-
         [Header("PoolList")]
-        public List<ObjectPool> Pools;
+        [SerializeField] private List<ObjectPool> _pools;
+        
+        public static ObjectPoolManager Instance;
+        public readonly Dictionary<string, ObjectPool> PoolsDic = new();
 
         private void Awake()
         {
@@ -18,9 +20,16 @@ namespace Yonii8.Unity.ObjectPooling
 
         private void Start()
         {
-            Pools.ForEach(p =>
+            _pools.ForEach(pool =>
             {
-                p.Initialise(gameObject.transform);
+                pool.Initialise(poolManager: gameObject.transform);
+
+                if (!PoolsDic.TryAdd(pool.name, pool))
+                {
+                    Debug.LogWarning(
+                        $"Pool {pool.name} could not be added to dictionary."
+                        );
+                }
             });
         }
     }

--- a/Runtime/Yonii8.Unity.ObjectPooling.asmdef
+++ b/Runtime/Yonii8.Unity.ObjectPooling.asmdef
@@ -1,3 +1,4 @@
 {
-	"name": "Yonii8.Unity.ObjectPooling"
+	"name": "Yonii8.Unity.ObjectPooling",
+	"references":[ "GUID:46503a97ad833044c8255fa9c55a74cf" ]
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+    "name": "com.yonii.unity.objectpooling",
+    "version": "1.0.0",
+    "displayName": "Yonii8.Unity.ObjectPooling",
+    "description": "Object Pooling",
+    "unity": "2022.3",
+    "unityRelease": "20f1",
+    "dependencies":{
+        "com.yonniie.unity.utilities": "0.0.2"
+    },
+    "author": {
+        "name": "yonii",
+        "email": "yonii@dragoonz.studio",
+        "url": ""
+    }
+}

--- a/package.json.meta
+++ b/package.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: e8744f1f6532c8547aa792ee917aa777
+PackageManifestImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
When ObjectPool is getting initialised it's going to look for all the PooledMonobehaviour rather than just one. Adding names based dictionary for looking up pools.